### PR TITLE
CI cleanup and multiple go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-env:
-  go-version: 1.18
-
 jobs:
-  test:
+  CI:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        GO_VERSION: ["1.18.x", "1.19.x", "1.20.x", "1.21.x"]
 
     steps:
       - uses: fkirc/skip-duplicate-actions@v4.0.0
@@ -21,27 +21,12 @@ jobs:
 
       - uses: actions/setup-go@v3.0.0
         with:
-          go-version: ${{ env.go-version }}
+          go-version: ${{ matrix.GO_VERSION }}
           check-latest: true
 
       - run: go test ./...
 
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: fkirc/skip-duplicate-actions@v4.0.0
-        with:
-          cancel_others: true
-
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v3.0.0
-        with:
-          go-version: ${{ env.go-version }}
-          check-latest: true
-
       - uses: golangci/golangci-lint-action@v2
         with:
-          args: --go=${{ env.go-version }}
+          args: --go=${{ matrix.go-version }}
           skip-go-installation: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  CI:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,7 +26,23 @@ jobs:
 
       - run: go test ./...
 
+  linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: fkirc/skip-duplicate-actions@v4.0.0
+        with:
+          cancel_others: true
+
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3.0.0
+        with:
+          go-version: "1.21.x"
+          check-latest: true
+
+      - run: go test ./...
+
       - uses: golangci/golangci-lint-action@v2
         with:
-          args: --go=${{ matrix.go-version }}
           skip-go-installation: true


### PR DESCRIPTION
- Test on all versions of go supporting generics
- Remove redundant `go test`
- Lint only on latest version of go.